### PR TITLE
Add logo image for header

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -33,6 +33,17 @@ body {
   box-shadow: var(--shadow);
 }
 
+header {
+  text-align: center;
+}
+
+header .logo {
+  max-width: 150px;
+  height: auto;
+  display: block;
+  margin: 0 auto 1rem;
+}
+
 header h1 {
   margin: 0 0 1rem;
   font-weight: 600;

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,9 @@
 <body>
   <div class="app-container glass">
     <header>
-      <h1>TODO</h1>
+      <h1>
+        <img class="logo" src="{{ url_for('static', filename='rogo.png') }}" alt="TODO Logo" />
+      </h1>
     </header>
 
     <main>


### PR DESCRIPTION
## Summary
- replace the TODO heading with the bundled `rogo.png`
- center the header content and style the logo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856717ade508323a6c099393fee28ef