### PR TITLE
Apply fluid glass style to task cards

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -77,15 +77,35 @@ header h1 {
 }
 
 .task-item {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 0;
-  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  background: rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(8px);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  box-shadow:
+    inset 0 0 8px rgba(255, 255, 255, 0.2),
+    0 4px 12px rgba(0, 0, 0, 0.4);
   opacity: 0;
   transform: translateY(10px);
   animation: fadeSlideIn 0.4s forwards;
   transition: box-shadow 0.3s, background 0.3s, transform 0.3s;
+  overflow: hidden;
+}
+
+.task-item::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg,
+      rgba(255, 255, 255, 0.4),
+      rgba(255, 255, 255, 0));
+  opacity: 0.15;
+  pointer-events: none;
 }
 
 .task-item label {
@@ -94,8 +114,11 @@ header h1 {
 }
 
 .task-item:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  background: rgba(255, 255, 255, 0.05);
+  box-shadow:
+    0 0 16px var(--accent),
+    inset 0 0 8px rgba(255, 255, 255, 0.3),
+    0 4px 16px rgba(0, 0, 0, 0.4);
+  background: rgba(255, 255, 255, 0.18);
   transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- redesign task list items with a translucent fluid glass look
- add gradient shine pseudo-element and glowing hover effect

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68567693dbfc832392323c5f7e82c9a5